### PR TITLE
Make ripple start at touchstart/mousedown

### DIFF
--- a/src/js/rippler.js
+++ b/src/js/rippler.js
@@ -25,18 +25,12 @@
             $this.on("touchstart."+ namespace, function(event) {
               var $self = $(this);
               methods.elementAdd.call(_this, $self, event);
-            });
-            $this.on("touchend." + namespace, function(event) {
-              var $self = $(this);
               methods.effect.call(_this, $self, event);
             });
           }else{
             $this.on("mousedown."+ namespace, function(event) {
               var $self = $(this);
               methods.elementAdd.call(_this, $self, event);
-            });
-            $this.on("mouseup."+ namespace, function(event) {
-              var $self = $(this);
               methods.effect.call(_this, $self, event);
             });
             


### PR DESCRIPTION
This makes the ripple effect start on touchstart/mousedown as its similar to what @Polymer and @angular in their own [material implementation](https://github.com/angular/material) do. 