### PR TITLE
Remove href attributes from buttons

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,7 @@ base_url: "./"
         <h3 class="site-section-sub-title">You can also use the buttons on the bootstrap.</h3>
         <ul class="list-inline site-example-nav">
           <li>
-            <a class="btn btn-default rippler rippler-inverse" href="#">
+            <a class="btn btn-default rippler rippler-inverse">
               <span class="oi oi-chevron-right"></span>
               &nbsp;rippler-inverse
             </a>
@@ -41,13 +41,13 @@ base_url: "./"
             </button>
           </li>
           <li>
-            <a class="btn btn-success rippler rippler-inverse" href="#">
+            <a class="btn btn-success rippler rippler-inverse">
               <span class="oi oi-check"></span>
               &nbsp;rippler-inverse
             </a>
           </li>
           <li>
-            <a class="btn btn-info rippler rippler-default" href="#">
+            <a class="btn btn-info rippler rippler-default">
               <span class="oi oi-info"></span>
               &nbsp;rippler-default
             </a>
@@ -56,13 +56,13 @@ base_url: "./"
 
         <ul class="list-inline site-example-nav">
           <li>
-            <a class="btn btn-warning btn-lg rippler rippler-inverse" href="#">
+            <a class="btn btn-warning btn-lg rippler rippler-inverse">
               <span class="oi oi-warning"></span>
               &nbsp;rippler-inverse
             </a>
           </li>
           <li>
-            <a class="btn btn-danger btn-lg rippler rippler-default" href="#">
+            <a class="btn btn-danger btn-lg rippler rippler-default">
               <span class="oi oi-ban"></span>
               &nbsp;rippler-default
             </a>
@@ -70,12 +70,12 @@ base_url: "./"
         </ul>
 
 {% highlight html %}
-<a class="btn btn-default rippler rippler-inverse" href="#">rippler-inverse</a>
+<a class="btn btn-default rippler rippler-inverse">rippler-inverse</a>
 <button class="btn btn-primary rippler rippler-default">rippler-default</button>
-<a class="btn btn-success rippler rippler-inverse" href="#">rippler-inverse</a>
-<a class="btn btn-info rippler rippler-default" href="#">rippler-default</a>
-<a class="btn btn-warning btn-lg rippler rippler-inverse" href="#">rippler-inverse</a>
-<a class="btn btn-danger btn-lg rippler rippler-default" href="#">rippler-default</a>
+<a class="btn btn-success rippler rippler-inverse">rippler-inverse</a>
+<a class="btn btn-info rippler rippler-default">rippler-default</a>
+<a class="btn btn-warning btn-lg rippler rippler-inverse">rippler-inverse</a>
+<a class="btn btn-danger btn-lg rippler rippler-default">rippler-default</a>
 {% endhighlight %}
       </div><!-- / .site-section-item -->
 
@@ -84,19 +84,19 @@ base_url: "./"
         <h3 class="site-section-sub-title">Link buttons with state colors</h3>
         <ul class="list-inline site-example-nav">
           <li>
-            <a class="btn btn-link rippler rippler-bs-primary" href="#">
+            <a class="btn btn-link rippler rippler-bs-primary">
               <span class="oi oi-star"></span>
               &nbsp;rippler-bs-primary
             </a>
           </li>
           <li>
-            <a class="btn btn-link rippler rippler-bs-success" href="#">
+            <a class="btn btn-link rippler rippler-bs-success">
               <span class="oi oi-check"></span>
               &nbsp;rippler-bs-success
             </a>
           </li>
           <li>
-            <a class="btn btn-link rippler rippler-bs-info" href="#">
+            <a class="btn btn-link rippler rippler-bs-info">
               <span class="oi oi-info"></span>
               &nbsp;rippler-bs-info
             </a>
@@ -105,24 +105,24 @@ base_url: "./"
 
         <ul class="list-inline site-example-nav">
           <li>
-            <a class="btn btn-link btn-lg rippler rippler-bs-warning" href="#">
+            <a class="btn btn-link btn-lg rippler rippler-bs-warning">
               <span class="oi oi-warning"></span>
               &nbsp;rippler-bs-warning
             </a>
           </li>
           <li>
-            <a class="btn btn-link btn-lg rippler rippler-bs-danger" href="#">
+            <a class="btn btn-link btn-lg rippler rippler-bs-danger">
               <span class="oi oi-ban"></span>
               &nbsp;rippler-bs-danger
             </a>
           </li>
         </ul>
 {% highlight html %}
-<a class="btn btn-link rippler rippler-bs-primary" href="#">...</a>
-<a class="btn btn-link rippler rippler-bs-success" href="#">...</a>
-<a class="btn btn-link rippler rippler-bs-info" href="#">...</a>
-<a class="btn btn-link btn-lg rippler rippler-bs-warning" href="#">...</a>
-<a class="btn btn-link btn-lg rippler rippler-bs-danger" href="#">...</a>
+<a class="btn btn-link rippler rippler-bs-primary">...</a>
+<a class="btn btn-link rippler rippler-bs-success">...</a>
+<a class="btn btn-link rippler rippler-bs-info">...</a>
+<a class="btn btn-link btn-lg rippler rippler-bs-warning">...</a>
+<a class="btn btn-link btn-lg rippler rippler-bs-danger">...</a>
 {% endhighlight %}
       </div><!-- / .site-section-item -->
 


### PR DESCRIPTION
Leaving `href="#"` on the anchors causes the page to jump to the top when a user clicks on it. It's not a nice user experience considering we want to see the ripple effect within the button.
