### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ You can also use the buttons on the bootstrap.
 
 ![demo image](./docs/assets/images/sample.gif)
 
-##Example & Installation
+## Example & Installation
 http://blivesta.github.io/rippler
 
-##Sidenote 
+## Sidenote 
 
 Due to click errors on firefox and safari is rippler using 0 for default effectSize!
 
@@ -26,5 +26,5 @@ $(document).ready(function() {
 });
 ```
 
-##License
+## License
 MIT license.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
